### PR TITLE
changes to FAST-Java for code export

### DIFF
--- a/src/Carrefour-FastAndBindingGenerator/CRFBinderVisitor.class.st
+++ b/src/Carrefour-FastAndBindingGenerator/CRFBinderVisitor.class.st
@@ -350,6 +350,11 @@ CRFBinderVisitor >> visitFASTJavaVariableDeclarator: aFASTJavaVariableDeclarator
 	super visitFASTJavaVariableDeclarator: aFASTJavaVariableDeclarator.
 ]
 
+{ #category : #generated }
+CRFBinderVisitor >> visitFASTJavaVariableExpression: aFASTJavaVariableExpression [
+	^self visitFASTTVariableExpression: aFASTJavaVariableExpression
+]
+
 { #category : #visitor }
 CRFBinderVisitor >> visitFASTTReturnStatement: aFASTReturnStatement [
 	aFASTReturnStatement expression


### PR DESCRIPTION
Changed `FASTJavaVariableExpression >> accept:` to call `#visitFASTJavaVariableExpression:` instead of `#visitFASTTVariableExpression:`

As a consequence, added  `#visitFASTJavaVariableExpression:` in CRFBinderVisitor that calls back its own `#visitFASTTVariableExpression:`